### PR TITLE
fix: 修復跨 repo 無法建立 PR 的問題

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = app => {
 
         const repo = get(context, 'payload.repository.name')
         const owner = get(context, 'payload.repository.owner.login')
-        const head = get(context, 'payload.pull_request.head.ref')
+        const head = get(context, 'payload.pull_request.head.label')
         const number = get(context, 'payload.pull_request.number')
         const assignees = get(context, 'payload.pull_request.assignees')
           .map(assignee => get(assignee, 'login'))
@@ -87,7 +87,7 @@ module.exports = app => {
             response_type: 'in_channel',
             attachments: [
               {
-                text: '需要本蛙爺再建立一個 merge 其它 branch 的 PR 嗎？',
+                text: '需要本蛙爺再幫你建立一個 merge 其它 branch 的 PR 嗎？',
                 fallback: '',
                 callback_id: 'pr_branch',
                 color: '#949EA6',


### PR DESCRIPTION
跨 repo 的 create a pull request API 的 head field 的格式要是 `username:branch`，原本使用的 ref 只是 `branch` 格式